### PR TITLE
Require working config for commands that need it

### DIFF
--- a/_official/lico-update.sh
+++ b/_official/lico-update.sh
@@ -491,6 +491,7 @@ if [ -r ${CONFFILE} ]; then
     . ${CONFFILE}
     if [ -z ${apikey+x} ]; then
         rm -fr ${CONFFILE}
+        unset machine_id
     fi
 fi
 
@@ -813,10 +814,11 @@ updateScript(){
     fi
 }
 
-if [ ! -r ${CONFFILE} ]; then
-    if [ ${interactive} -eq 0 ]; then
-        echo "Config file not found!"
-        echo "Please run \"${SCRIPTNAME} -i\" first."
+# Require working configuration for commands which need it
+if [ -z ${machine_id+x} ]; then
+    if [[ ${installcron} -eq 1 ]] || [[ ${showdata} -eq 1 ]] || [[ ${senddata} -eq 1 ]]; then
+        echo "Configuration is missing or incomplete!"
+        echo "Please run \"${SCRIPTNAME} -i\" first and register this machine."
         exit 1
     fi
 fi
@@ -948,7 +950,14 @@ if [ ${interactive} -eq 1 ]; then
     fi
 
     if [ ${interactive_action} -eq 5 ]; then
-        installCronjob
+        if [ "${machine_id}" != "" ]; then
+            installCronjob
+        else
+            echo "! Machine ID is unknown."
+            echo "! Please register this machine first. (\"${SCRIPTNAME} -i\" and then choose [1])"
+            echo ""
+            exit 1
+        fi
     fi
 
     if [ ${interactive_action} -eq 6 ]; then


### PR DESCRIPTION
lico-update.sh previously checked that the configuration file exists for
all commands except interactive mode. This prevented showing the help or
version for new users that hadn't run interactive mode and registered
their machine yet. The script now only requires $machine_id to be set
for commands that actively use it, now or later (installing the cronjob
will require a working config).
Also introduces the check for installing the cronjob in interactive
mode.

TODO: Seperate showing machine data and actually sending it. Showing
the data should be possible without even registering a user account.